### PR TITLE
Removed Prompt Logic

### DIFF
--- a/_posts/2020-03-15-week07.md
+++ b/_posts/2020-03-15-week07.md
@@ -7,7 +7,6 @@ title: Week 7
 
 **Wikipedia**
 - Contributing to Wikipedia seems intense, due to the wide scope of it, but after reading through the [Getting started](https://en.wikipedia.org/wiki/Wikipedia:Contributing_to_Wikipedia#Getting_started) guide on Wikipedia, I feel a lot more confident in making my first contribution. They addressed some of the issues that I was tentative on, such as the fact that it's **okay** to not understand everything at first.
-Rummage around in Wikipedia looking for pages that you think you might be able to edit. In your weekly blog, write about what you find, or what you discovered and what was hard.
 
 Some Wikipedia pages I think I might be able to edit are:
 - [**Subtle Asian Traits**](https://en.wikipedia.org/wiki/Subtle_Asian_Traits) - This is a huge Facebook group that garnered over a million members, connecting Asians worldwide. I think contributing to this page might be within my area of expertise, since I am an administrator of a sister Facebook group that has over 10,000 members, named Subtle Asian Tech. In this group, we provide resume review and career advice to a large tech community!


### PR DESCRIPTION
Super interesting blog post! Removed some _prompt_ logic left behind.

Specifically the chunk below under the Wikipedia heading:

**Rummage around in Wikipedia looking for pages that you think you might be able to edit. In your weekly blog, write about what you find, or what you discovered and what was hard.**